### PR TITLE
Fixed bug in AbstractEnforcerRule

### DIFF
--- a/enforcer-rule/src/main/java/org/semver/enforcer/AbstractEnforcerRule.java
+++ b/enforcer-rule/src/main/java/org/semver/enforcer/AbstractEnforcerRule.java
@@ -190,7 +190,7 @@ public abstract class AbstractEnforcerRule implements EnforcerRule {
 
     protected final List<ArtifactVersion> filterNonPreviousVersions(final List<ArtifactVersion> availableVersions, final Version version) {
         final List<ArtifactVersion> versions = new ArrayList<ArtifactVersion>();
-        for (final ArtifactVersion artifactVersion : versions) {
+        for (final ArtifactVersion artifactVersion : availableVersions) {
             if (version.compareTo(Version.parse(artifactVersion.toString())) > 0) {
                 versions.add(artifactVersion);
             }


### PR DESCRIPTION
filterNonPreviousVersions was iterating the wrong list (versions) this should be availableVersions
