### PR TITLE
Main.java now uses the --new-jar argument correctly.

### DIFF
--- a/api/src/main/java/org/semver/Main.java
+++ b/api/src/main/java/org/semver/Main.java
@@ -101,7 +101,7 @@ public class Main {
             System.exit(0);
         }
 
-        final Comparer comparer = new Comparer(new File(config.baseJar), new File(config.baseJar), config.includes,
+        final Comparer comparer = new Comparer(new File(config.baseJar), new File(config.newJar), config.includes,
                 config.excludes);
         final Delta delta = comparer.diff();
 


### PR DESCRIPTION
This change fixes a problem in Main.jara where the Compare object is instantiated with baseJar for both the currentJar and previousJar arguments. This meant that the program will only compare "baseJar" to itself.
