### PR TITLE
Add superclass handling

### DIFF
--- a/api/src/main/java/org/osjava/jardiff/JarDiff.java
+++ b/api/src/main/java/org/osjava/jardiff/JarDiff.java
@@ -436,8 +436,6 @@ public class JarDiff
                     MethodInfo newInfo = (MethodInfo) newMethods.get(desc);
                     if (!criteria.differs(oldInfo, newInfo))
                         j.remove();
-                    else if (oldInfo.isPrivate() && newInfo.isPrivate())
-                        j.remove();
                 }
                 j = changedFields.iterator();
                 while (j.hasNext()) {
@@ -446,8 +444,6 @@ public class JarDiff
                     FieldInfo newInfo = (FieldInfo) newFields.get(desc);
                     if (!criteria.differs(oldInfo, newInfo))
                         j.remove();
-                    else if (oldInfo.isPrivate() && newInfo.isPrivate())
-                        j.remove();;
                 }
                 boolean classchanged = criteria.differs(oci, nci);
                 if (classchanged || !removedMethods.isEmpty()

--- a/api/src/test/java/org/semver/jardiff/ClassInheritanceTest.java
+++ b/api/src/test/java/org/semver/jardiff/ClassInheritanceTest.java
@@ -81,8 +81,12 @@ public class ClassInheritanceTest {
     addClassInfo(newClassInfoMap, InheritanceRoot.class, jd, loadInfoMethod);
 
     // Make B look like A
-    newClassInfoMap.put(ClassA.class.getName(), newClassInfoMap.get(ClassB.class.getName()));
-    newClassInfoMap.remove(ClassB.class.getName());
+    ClassInfo a = oldClassInfoMap.get("org/semver/jardiff/ClassInheritanceTest$ClassA");
+    ClassInfo b = newClassInfoMap.get("org/semver/jardiff/ClassInheritanceTest$ClassB");
+    newClassInfoMap.put(a.getName(), new ClassInfo(b.getVersion(), b.getAccess(), a.getName(),
+            b.getSignature(), b.getSupername(), b.getInterfaces(),
+            b.getMethodMap(), b.getFieldMap()));
+    newClassInfoMap.remove(b.getName());
     DifferenceAccumulatingHandler handler = new DifferenceAccumulatingHandler();
     diffMethod.invoke(jd, handler, new SimpleDiffCriteria(),
         "0.1.0", "0.2.0", oldClassInfoMap, newClassInfoMap);
@@ -94,13 +98,13 @@ public class ClassInheritanceTest {
         System.err.println("  : " + ((Change) d).getModifiedInfo().getName());
       }
     }
-    Assert.assertEquals("differences found", 0, handler.getDelta().getDifferences().size());
+    Assert.assertEquals("differences found", 1, handler.getDelta().getDifferences().size());
   }
 
   private void addClassInfo(Map<String, ClassInfo> classMap, Class klass, JarDiff jd,
       Method loadInfoMethod) throws IllegalArgumentException, IllegalAccessException, InvocationTargetException, IOException {
-    ClassInfo classInfo = (ClassInfo) loadInfoMethod.invoke(jd, new ClassReader(ClassA.class.getName()));
-    classMap.put(klass.getName(), classInfo);
+    ClassInfo classInfo = (ClassInfo) loadInfoMethod.invoke(jd, new ClassReader(klass.getName()));
+    classMap.put(classInfo.getName(), classInfo);
   }
 
 }

--- a/api/src/test/java/org/semver/jardiff/DeprecateDetectionTest.java
+++ b/api/src/test/java/org/semver/jardiff/DeprecateDetectionTest.java
@@ -91,8 +91,9 @@ public class DeprecateDetectionTest {
     addClassInfo(newClassInfoMap, InheritanceRoot.class, jd, loadInfoMethod);
 
     // Make B look like A
-    newClassInfoMap.put(ClassA.class.getName(), newClassInfoMap.get(ClassB.class.getName()));
-    newClassInfoMap.remove(ClassB.class.getName());
+    newClassInfoMap.put("org/semver/jardiff/DeprecateDetectionTest$ClassA",
+            newClassInfoMap.get("org/semver/jardiff/DeprecateDetectionTest$ClassB"));
+    newClassInfoMap.remove("org/semver/jardiff/DeprecateDetectionTest$ClassB");
     DifferenceAccumulatingHandler handler = new DifferenceAccumulatingHandler();
     diffMethod.invoke(jd, handler, new SimpleDiffCriteria(),
         "0.1.0", "0.2.0", oldClassInfoMap, newClassInfoMap);
@@ -113,6 +114,6 @@ public class DeprecateDetectionTest {
   private void addClassInfo(Map<String, ClassInfo> classMap, Class klass, JarDiff jd,
       Method loadInfoMethod) throws IllegalArgumentException, IllegalAccessException, InvocationTargetException, IOException {
     ClassInfo classInfo = (ClassInfo) loadInfoMethod.invoke(jd, new ClassReader(klass.getName()));
-    classMap.put(klass.getName(), classInfo);
+    classMap.put(classInfo.getName(), classInfo);
   }
 }


### PR DESCRIPTION
I modified JarDiff to take the superclass fields and methods into account in the comparison. This improves the comparison results for cases where members are moved upwards in the class hierarchy.
