### PR TITLE
fix pre version comparison

### DIFF
--- a/api/src/main/java/org/semver/Version.java
+++ b/api/src/main/java/org/semver/Version.java
@@ -125,11 +125,23 @@ public final class Version implements Comparable<Version> {
 
         switch (element) {
             case MAJOR:
-                return new Version(this.major+1, 0, 0);
+              if (special == null || this.minor != 0 || this.patch != 0) {
+                return new Version(this.major + 1, 0, 0);
+              } else {
+                return new Version(this.major, 0, 0);
+              }
             case MINOR:
-                return new Version(this.major, this.minor+1, 0);
+              if (special == null || this.patch != 0) {
+                return new Version(this.major, this.minor + 1, 0);
+              } else {
+                return new Version(this.major, this.minor, 0);
+              }
             case PATCH:
-                return new Version(this.major, this.minor, this.patch+1);
+              if (special == null) {
+                return new Version(this.major, this.minor, this.patch + 1);
+              } else {
+                return new Version(this.major, this.minor, this.patch);
+              }
             default:
                 throw new IllegalArgumentException("Unknown element <"+element+">");
         }

--- a/api/src/test/java/org/semver/VersionTest.java
+++ b/api/src/test/java/org/semver/VersionTest.java
@@ -143,6 +143,25 @@ public class VersionTest {
         Assert.assertEquals(version.next(Version.Element.PATCH), new Version(major, minor, patch+1));
     }
 
+    @Test
+    public void nextFromPre() {
+        final Version version1 = new Version(1, 0, 0, "-", "rc1");
+        Assert.assertEquals(new Version(1, 0, 0), version1.next(Version.Element.MAJOR));
+        Assert.assertEquals(new Version(1, 0, 0), version1.next(Version.Element.MINOR));
+        Assert.assertEquals(new Version(1, 0, 0), version1.next(Version.Element.PATCH));
+
+        final Version version2 = new Version(1, 1, 0, "-", "rc1");
+        Assert.assertEquals(new Version(2, 0, 0), version2.next(Version.Element.MAJOR));
+        Assert.assertEquals(new Version(1, 1, 0), version2.next(Version.Element.MINOR));
+        Assert.assertEquals(new Version(1, 1, 0), version2.next(Version.Element.PATCH));
+
+        final Version version3 = new Version(1, 1, 1, "-", "rc1");
+        Assert.assertEquals(new Version(2, 0, 0), version3.next(Version.Element.MAJOR));
+        Assert.assertEquals(new Version(1, 2, 0), version3.next(Version.Element.MINOR));
+        Assert.assertEquals(new Version(1, 1, 1), version3.next(Version.Element.PATCH));
+    }
+
+
     @Test(expected=IllegalArgumentException.class)
     public void shouldNextWithNullComparisonTypeFail() {
         final int major = 1;


### PR DESCRIPTION
Fixing the Version comparison according to http://semver.org/

> \11. Precedence refers to how versions are compared to each other when ordered. Precedence MUST be calculated by separating the version into major, minor, patch and pre-release identifiers in that order (Build metadata does not figure into precedence). Precedence is determined by the first difference when comparing each of these identifiers from left to right as follows: Major, minor, and patch versions are always compared numerically. Example: 1.0.0 < 2.0.0 < 2.1.0 < 2.1.1. When major, minor, and patch are equal, a pre-release version has lower precedence than a normal version. Example: 1.0.0-alpha < 1.0.0. Precedence for two pre-release versions with the same major, minor, and patch version MUST be determined by comparing each dot separated identifier from left to right until a difference is found as follows: identifiers consisting of only digits are compared numerically and identifiers with letters or hyphens are compared lexically in ASCII sort order. Numeric identifiers always have lower precedence than non-numeric identifiers. A larger set of pre-release fields has a higher precedence than a smaller set, if all of the preceding identifiers are equal. Example: 1.0.0-alpha < 1.0.0-alpha.1 < 1.0.0-alpha.beta < 1.0.0-beta < 1.0.0-beta.2 < 1.0.0-beta.11 < 1.0.0-rc.1 < 1.0.0.

In particular pre-release versions were not compared according to this example.
See new test cases in VersionTest.isNewer()

Also fixing the next() version implementation.
If a version is a pre release then the next version should be a release.

for context: This is currently blocking the Parquet build as the enforcer plugin wants a new minor release on top of our rc.
https://travis-ci.org/apache/incubator-parquet-mr/builds/33395476
