### PR TITLE
Improve handling of class changes.

### DIFF
--- a/api/src/main/java/org/osjava/jardiff/ClassInfo.java
+++ b/api/src/main/java/org/osjava/jardiff/ClassInfo.java
@@ -35,15 +35,23 @@ public final class ClassInfo extends AbstractInfo
     private final String signature;
 
     /**
+     * The formal type parameters
+     */
+    private final String formalTypeParams;
+
+    /**
      * The internal classname of the superclass.
      */
     private final String supername;
 
+    private final String superClassSignature;
+
     /**
-     * An array of names of internal classnames of interfaces implemented
+     * A map of names of internal classnames of interfaces implemented
      * by the class.
+     * Keyed by interface name, value is the type signature for the interface.
      */
-    private final String[] interfaces;
+    private final Map<String, String> interfaces;
 
     /**
      * A map of method signature to MethodInfo, for the methods provided
@@ -69,13 +77,15 @@ public final class ClassInfo extends AbstractInfo
      * @param methodMap a map of methods provided by this class.
      * @param fieldMap a map of fields provided by this class.
      */
-    public ClassInfo(int version, int access, String name, String signature,
-                     String supername, String[] interfaces, Map<String, MethodInfo> methodMap,
-                     Map<String, FieldInfo> fieldMap) {
+    public ClassInfo(int version, int access, String name, String signature, String formalTypeParams,
+                     String supername, String superSignature, Map<String, String> interfaces,
+                     Map<String, MethodInfo> methodMap, Map<String, FieldInfo> fieldMap) {
         super(access, name);
         this.version = version;
         this.signature = signature;
+        this.formalTypeParams = formalTypeParams;
         this.supername = supername;
+        this.superClassSignature = superSignature;
         this.interfaces = interfaces;
         this.methodMap = methodMap;
         this.fieldMap = fieldMap;
@@ -115,7 +125,7 @@ public final class ClassInfo extends AbstractInfo
      * @return an array of internal names of classes implemented by the class.
      */
     public final String[] getInterfaces() {
-        return interfaces;
+        return interfaces.keySet().toArray(new String[0]);
     }
 
     /**
@@ -134,5 +144,26 @@ public final class ClassInfo extends AbstractInfo
      */
     public final Map<String, FieldInfo> getFieldMap() {
         return fieldMap;
+    }
+
+    /**
+     * Get the full signature of the super class, including any type parameters.
+     */
+    public String getSuperClassSignature() {
+        return superClassSignature;
+    }
+
+    /**
+     * Get the formal type parameters declared for this class, if they exist.
+     */
+    public String getFormalTypeParams() {
+        return formalTypeParams;
+    }
+
+    /**
+     * Get the map of interfaces and their corresponding type signatures.
+     */
+    public final Map<String, String> getInterfaceSignatures() {
+        return interfaces;
     }
 }

--- a/api/src/main/java/org/osjava/jardiff/JarDiff.java
+++ b/api/src/main/java/org/osjava/jardiff/JarDiff.java
@@ -520,8 +520,9 @@ public class JarDiff
     private static ClassInfo cloneDeprecated(ClassInfo classInfo) {
 	return new ClassInfo(classInfo.getVersion(), classInfo.getAccess()
 		| Opcodes.ACC_DEPRECATED, classInfo.getName(),
-		classInfo.getSignature(), classInfo.getSupername(),
-		classInfo.getInterfaces(), classInfo.getMethodMap(),
+		classInfo.getSignature(), classInfo.getFormalTypeParams(),
+        classInfo.getSupername(), classInfo.getSuperClassSignature(),
+		classInfo.getInterfaceSignatures(), classInfo.getMethodMap(),
 		classInfo.getFieldMap());
     }
 

--- a/api/src/main/java/org/semver/Delta.java
+++ b/api/src/main/java/org/semver/Delta.java
@@ -199,8 +199,8 @@ public final class Delta {
 
                     List<String> oldInterfaces = Arrays.asList(oldClassInfo.getInterfaces());
                     List<String> newInterfaces = Arrays.asList(newClassInfo.getInterfaces());
-
                     List<String> interfaceIntersection = new ArrayList<String>(newInterfaces);
+                    interfaceIntersection.retainAll(oldInterfaces);
 
                     if (interfaceIntersection.size() < oldInterfaces.size()) {
                         // Old set of interfaces is not a subset of the new set of interfaces.

--- a/api/src/test/java/org/semver/DeltaTest.java
+++ b/api/src/test/java/org/semver/DeltaTest.java
@@ -204,6 +204,13 @@ public class DeltaTest {
         validate(singleton(new Delta.Change("class", oldClassInfo, newClassInfo)), new Version(1, 1, 0), new Version(1, 2, 0), false);
     }
 
+    @Test
+    public void classByteChangeIsIncompatible() {
+        ClassInfo oldClassInfo = new ClassInfo(V1_7, ACC_PUBLIC, "class", "class Foo", "super", new String[0], null, null);
+        ClassInfo newClassInfo = new ClassInfo(V1_8, ACC_PUBLIC, "class", "class Foo", "super", new String[0], null, null);
+        validate(singleton(new Delta.Change("class", oldClassInfo, newClassInfo)), new Version(1, 1, 0), new Version(1, 2, 0), false);
+    }
+
     private void validate(Set<? extends Delta.Difference> differences, Version previous, Version current, boolean valid) {
       assertEquals(
           "accept differences " + differences + " when changing version from " + previous + " to " + current,

--- a/api/src/test/java/org/semver/DeltaTest.java
+++ b/api/src/test/java/org/semver/DeltaTest.java
@@ -191,6 +191,13 @@ public class DeltaTest {
     }
 
     @Test
+    public void changedInterfaceOnClassIsIncompatible() {
+        ClassInfo oldClassInfo = new ClassInfo(V1_8, ACC_PUBLIC, "class", "class Foo", "super", new String[] { "Interface1" }, null, null);
+        ClassInfo newClassInfo = new ClassInfo(V1_8, ACC_PUBLIC, "class", "class Foo", "super", new String[] { "Interface2" }, null, null);
+        validate(singleton(new Delta.Change("class", oldClassInfo, newClassInfo)), new Version(1, 1, 0), new Version(1, 2, 0), false);
+    }
+
+    @Test
     public void classVisibilityChangeIsIncompatible() {
         ClassInfo oldClassInfo = new ClassInfo(V1_8, ACC_PUBLIC, "class", "class Foo", "super", new String[0], null, null);
         ClassInfo newClassInfo = new ClassInfo(V1_8, ACC_PRIVATE, "class", "class Foo", "super", new String[0], null, null);

--- a/api/src/test/java/org/semver/DeltaTest.java
+++ b/api/src/test/java/org/semver/DeltaTest.java
@@ -30,6 +30,7 @@ import static org.semver.Version.Element.PATCH;
 import org.semver.Delta.Difference;
 
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.Set;
 
 import org.junit.Test;
@@ -163,7 +164,7 @@ public class DeltaTest {
 
     @Test
     public void upgradeMinorVersionOnClassDeprecated() {
-      validate(singleton(new Delta.Deprecate("class", new ClassInfo(1, 0, "", "", "", null, null, null), new ClassInfo(1, 0, "", "", "", null, null, null))), new Version(1, 1, 0), new Version(1, 2, 0), true);
+      validate(singleton(new Delta.Deprecate("class", new ClassInfo(1, 0, "", "", "", "", "", null, null, null), new ClassInfo(1, 0, "", "", "", "", "", null, null, null))), new Version(1, 1, 0), new Version(1, 2, 0), true);
     }
 
     @Test
@@ -178,44 +179,75 @@ public class DeltaTest {
 
     @Test
     public void addedInterfaceOnClassIsCompatible() {
-        ClassInfo oldClassInfo = new ClassInfo(V1_8, ACC_PUBLIC, "class", "class Foo", "super", new String[] { "Interface1" }, null, null);
-        ClassInfo newClassInfo = new ClassInfo(V1_8, ACC_PUBLIC, "class", "class Foo", "super", new String[] { "Interface1", "Interface2" }, null, null);
+        HashMap<String, String> interfacesA = new HashMap<String, String>();
+        interfacesA.put("Interface1", "");
+        HashMap<String, String> interfacesB = new HashMap<String, String>();
+        interfacesB.put("Interface1", "");
+        interfacesB.put("Interface2", "");
+
+        ClassInfo oldClassInfo = new ClassInfo(V1_8, ACC_PUBLIC, "class", "class Foo", "", "super", "super", interfacesA, null, null);
+        ClassInfo newClassInfo = new ClassInfo(V1_8, ACC_PUBLIC, "class", "class Foo", "", "super", "super", interfacesB, null, null);
         validate(singleton(new Delta.Change("class", oldClassInfo, newClassInfo)), new Version(1, 1, 0), new Version(1, 2, 0), true);
     }
 
     @Test
     public void removeInterfaceOnClassIsIncompatible() {
-        ClassInfo oldClassInfo = new ClassInfo(V1_8, ACC_PUBLIC, "class", "class Foo", "super", new String[] { "Interface1", "Interface2" }, null, null);
-        ClassInfo newClassInfo = new ClassInfo(V1_8, ACC_PUBLIC, "class", "class Foo", "super", new String[] { "Interface1" }, null, null);
+        HashMap<String, String> interfacesA = new HashMap<String, String>();
+        interfacesA.put("Interface1", "");
+        interfacesA.put("Interface2", "");
+        HashMap<String, String> interfacesB = new HashMap<String, String>();
+        interfacesB.put("Interface1", "");
+
+        ClassInfo oldClassInfo = new ClassInfo(V1_8, ACC_PUBLIC, "class", "class Foo", "", "super", "super", interfacesA, null, null);
+        ClassInfo newClassInfo = new ClassInfo(V1_8, ACC_PUBLIC, "class", "class Foo", "", "super", "super", interfacesB, null, null);
         validate(singleton(new Delta.Change("class", oldClassInfo, newClassInfo)), new Version(1, 1, 0), new Version(1, 2, 0), false);
     }
 
     @Test
     public void changedInterfaceOnClassIsIncompatible() {
-        ClassInfo oldClassInfo = new ClassInfo(V1_8, ACC_PUBLIC, "class", "class Foo", "super", new String[] { "Interface1" }, null, null);
-        ClassInfo newClassInfo = new ClassInfo(V1_8, ACC_PUBLIC, "class", "class Foo", "super", new String[] { "Interface2" }, null, null);
+        HashMap<String, String> interfacesA = new HashMap<String, String>();
+        interfacesA.put("Interface1", "");
+        HashMap<String, String> interfacesB = new HashMap<String, String>();
+        interfacesB.put("Interface2", "");
+
+        ClassInfo oldClassInfo = new ClassInfo(V1_8, ACC_PUBLIC, "class", "class Foo", "", "super", "super", interfacesA, null, null);
+        ClassInfo newClassInfo = new ClassInfo(V1_8, ACC_PUBLIC, "class", "class Foo", "", "super", "super", interfacesB, null, null);
         validate(singleton(new Delta.Change("class", oldClassInfo, newClassInfo)), new Version(1, 1, 0), new Version(1, 2, 0), false);
     }
 
     @Test
     public void classVisibilityChangeIsIncompatible() {
-        ClassInfo oldClassInfo = new ClassInfo(V1_8, ACC_PUBLIC, "class", "class Foo", "super", new String[0], null, null);
-        ClassInfo newClassInfo = new ClassInfo(V1_8, ACC_PRIVATE, "class", "class Foo", "super", new String[0], null, null);
+        ClassInfo oldClassInfo = new ClassInfo(V1_8, ACC_PUBLIC, "class", "class Foo", "", "super", "super", Collections.EMPTY_MAP, null, null);
+        ClassInfo newClassInfo = new ClassInfo(V1_8, ACC_PRIVATE, "class", "class Foo", "", "super", "super", Collections.EMPTY_MAP, null, null);
         validate(singleton(new Delta.Change("class", oldClassInfo, newClassInfo)), new Version(1, 1, 0), new Version(1, 2, 0), false);
     }
 
     @Test
     public void classSuperChangeIsIncompatible() {
-        ClassInfo oldClassInfo = new ClassInfo(V1_8, ACC_PUBLIC, "class", "class Foo", "super", new String[0], null, null);
-        ClassInfo newClassInfo = new ClassInfo(V1_8, ACC_PUBLIC, "class", "class Foo", "newsuper", new String[0], null, null);
+        ClassInfo oldClassInfo = new ClassInfo(V1_8, ACC_PUBLIC, "class", "class Foo", "", "super", "super", Collections.EMPTY_MAP, null, null);
+        ClassInfo newClassInfo = new ClassInfo(V1_8, ACC_PUBLIC, "class", "class Foo", "", "newsuper", "newsuper", Collections.EMPTY_MAP, null, null);
         validate(singleton(new Delta.Change("class", oldClassInfo, newClassInfo)), new Version(1, 1, 0), new Version(1, 2, 0), false);
     }
 
     @Test
     public void classByteChangeIsIncompatible() {
-        ClassInfo oldClassInfo = new ClassInfo(V1_7, ACC_PUBLIC, "class", "class Foo", "super", new String[0], null, null);
-        ClassInfo newClassInfo = new ClassInfo(V1_8, ACC_PUBLIC, "class", "class Foo", "super", new String[0], null, null);
+        ClassInfo oldClassInfo = new ClassInfo(V1_7, ACC_PUBLIC, "class", "class Foo", "", "super", "super", Collections.EMPTY_MAP, null, null);
+        ClassInfo newClassInfo = new ClassInfo(V1_8, ACC_PUBLIC, "class", "class Foo", "", "super", "super", Collections.EMPTY_MAP, null, null);
         validate(singleton(new Delta.Change("class", oldClassInfo, newClassInfo)), new Version(1, 1, 0), new Version(1, 2, 0), false);
+    }
+
+    @Test
+    public void testClassBecomesFinalIsUserCompatible() {
+        ClassInfo oldClassInfo = new ClassInfo(V1_8, ACC_PUBLIC, "class", "class Foo", "", "super", "super", Collections.EMPTY_MAP, null, null);
+        ClassInfo newClassInfo = new ClassInfo(V1_8, ACC_PUBLIC | ACC_FINAL, "class", "class Foo", "", "super", "super", Collections.EMPTY_MAP, null, null);
+        validateCompatibility(singleton(new Delta.Change("class", oldClassInfo, newClassInfo)), BACKWARD_COMPATIBLE_USER);
+    }
+
+    @Test
+    public void testClassBecomesAbstractIsIncompatible() {
+        ClassInfo oldClassInfo = new ClassInfo(V1_8, ACC_PUBLIC, "class", "class Foo", "", "super", "super", Collections.EMPTY_MAP, null, null);
+        ClassInfo newClassInfo = new ClassInfo(V1_8, ACC_PUBLIC | ACC_ABSTRACT, "class", "class Foo", "", "super", "super", Collections.EMPTY_MAP, null, null);
+        validateCompatibility(singleton(new Delta.Change("class", oldClassInfo, newClassInfo)), NON_BACKWARD_COMPATIBLE);
     }
 
     private void validate(Set<? extends Delta.Difference> differences, Version previous, Version current, boolean valid) {
@@ -223,5 +255,9 @@ public class DeltaTest {
           "accept differences " + differences + " when changing version from " + previous + " to " + current,
           valid,
           new Delta(differences).validate(previous, current));
+    }
+
+    private void validateCompatibility(Set<? extends Delta.Difference> differences, Delta.CompatibilityType expectedCompatibility) {
+        assertEquals(expectedCompatibility, new Delta(differences).computeCompatibilityType());
     }
 }

--- a/api/src/test/java/org/semver/jardiff/ClassInheritanceTest.java
+++ b/api/src/test/java/org/semver/jardiff/ClassInheritanceTest.java
@@ -72,7 +72,7 @@ public class ClassInheritanceTest {
     ClassInfo a = oldClassInfoMap.get("org/semver/jardiff/ClassInheritanceTest$ClassA");
     ClassInfo b = newClassInfoMap.get("org/semver/jardiff/ClassInheritanceTest$ClassB");
     newClassInfoMap.put(a.getName(), new ClassInfo(b.getVersion(), b.getAccess(), a.getName(),
-            b.getSignature(), b.getSupername(), b.getInterfaces(),
+            b.getSignature(), "", b.getSupername(), "", b.getInterfaceSignatures(),
             b.getMethodMap(), b.getFieldMap()));
     newClassInfoMap.remove(b.getName());
     DifferenceAccumulatingHandler handler = new DifferenceAccumulatingHandler();


### PR DESCRIPTION
- Actually drill into Changes now, instead of treating all as incompatible.
- Mark interface additions to a class as user backwards compatible
- Treat everything else, including bytecode version changes, as incompatible.

This change ensures that a class changing from `public class Foo` to `public class Foo implements Stuff` is still considered `BACKWARDS_COMPATIBLE_USER`.
